### PR TITLE
UI Color Palette /one 5.1.5 Syrah

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "@a_ng_d/figmug-ui": "^1.19.43",
         "@a_ng_d/figmug-utils": "^0.7.3",
-        "@a_ng_d/utils-ui-color-palette": "^1.7.6",
+        "@a_ng_d/utils-ui-color-palette": "^1.7.8",
         "@mistralai/mistralai": "^1.10.0",
         "@nanostores/preact": "^0.5.2",
         "@sentry/react": "^9.27.0",
@@ -91,9 +91,9 @@
       "license": "MIT"
     },
     "node_modules/@a_ng_d/utils-ui-color-palette": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@a_ng_d/utils-ui-color-palette/-/utils-ui-color-palette-1.7.6.tgz",
-      "integrity": "sha512-vN6VfKNqr6XEQkA4nW0H7VgZYQnAuxnjEr81L3z1WMUD3TfKKJ5JLU4Oa1DOx3rIaSIQx6AM2y5iAMws/ewlhg==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@a_ng_d/utils-ui-color-palette/-/utils-ui-color-palette-1.7.8.tgz",
+      "integrity": "sha512-KbNinqloqnAlH/aGYW3Opzjr/9JDwvLBaqOLU4BC+sXh2PDENns6T8loUlm935BhD+9XT83Ao/LdgJQIrqZ1rA==",
       "license": "MIT",
       "dependencies": {
         "@a_ng_d/figmug-utils": "^0.4.0",
@@ -9423,7 +9423,7 @@
       }
     },
     "packages/ui-ui-color-palette": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "MIT",
       "workspaces": [
         "packages/announcements-yelbolt-worker",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "update:uicp": "npm i @a_ng_d/utils-ui-color-palette@latest",
     "start:ext": "npm run start:ext -w ui-ui-color-palette",
     "start:dev": "npm run build & vite preview",
-    "build": "cross-env npx vite build --mode development && IS_PLUGIN=true cross-env npx vite build --mode development",
+    "build": "cross-env npx vite build --mode development & IS_PLUGIN=true cross-env npx vite build --mode development",
     "build:prod": "cross-env npx vite build --mode production && IS_PLUGIN=true cross-env npx vite build --mode production",
     "typecheck": "npx tsc --noEmit",
     "lint": "npx eslint ./src/** --fix --ext .ts,.tsx .",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@a_ng_d/figmug-ui": "^1.19.43",
     "@a_ng_d/figmug-utils": "^0.7.3",
-    "@a_ng_d/utils-ui-color-palette": "^1.7.6",
+    "@a_ng_d/utils-ui-color-palette": "^1.7.8",
     "@mistralai/mistralai": "^1.10.0",
     "@nanostores/preact": "^0.5.2",
     "@sentry/react": "^9.27.0",

--- a/src/bridges/loadUI.ts
+++ b/src/bridges/loadUI.ts
@@ -109,8 +109,10 @@ const loadUI = async () => {
         updateDocument(path.view)
           .finally(() => penpot.ui.sendMessage({ type: 'STOP_LOADER' }))
           .catch((error) => {
-            console.error(error)
-
+            penpot.ui.sendMessage({
+              type: 'REPORT_ERROR',
+              data: error,
+            })
             penpot.ui.sendMessage({
               type: 'POST_MESSAGE',
               data: {
@@ -128,8 +130,10 @@ const loadUI = async () => {
         createPalette(path)
           .finally(() => penpot.ui.sendMessage({ type: 'STOP_LOADER' }))
           .catch((error) => {
-            console.error(error)
-
+            penpot.ui.sendMessage({
+              type: 'REPORT_ERROR',
+              data: error,
+            })
             penpot.ui.sendMessage({
               type: 'POST_MESSAGE',
               data: {
@@ -142,8 +146,10 @@ const loadUI = async () => {
         createPaletteFromDocument()
           .finally(() => penpot.ui.sendMessage({ type: 'STOP_LOADER' }))
           .catch((error) => {
-            console.error(error)
-
+            penpot.ui.sendMessage({
+              type: 'REPORT_ERROR',
+              data: error,
+            })
             penpot.ui.sendMessage({
               type: 'POST_MESSAGE',
               data: {
@@ -156,8 +162,10 @@ const loadUI = async () => {
         createPaletteFromRemote(path)
           .finally(() => penpot.ui.sendMessage({ type: 'STOP_LOADER' }))
           .catch((error) => {
-            console.error(error)
-
+            penpot.ui.sendMessage({
+              type: 'REPORT_ERROR',
+              data: error,
+            })
             penpot.ui.sendMessage({
               type: 'POST_MESSAGE',
               data: {
@@ -181,8 +189,10 @@ const loadUI = async () => {
           )
           .finally(() => penpot.ui.sendMessage({ type: 'STOP_LOADER' }))
           .catch((error) => {
-            console.error(error)
-
+            penpot.ui.sendMessage({
+              type: 'REPORT_ERROR',
+              data: error,
+            })
             penpot.ui.sendMessage({
               type: 'POST_MESSAGE',
               data: {
@@ -195,8 +205,10 @@ const loadUI = async () => {
         createDocument(path.id, path.view)
           .finally(() => penpot.ui.sendMessage({ type: 'STOP_LOADER' }))
           .catch((error) => {
-            console.error(error)
-
+            penpot.ui.sendMessage({
+              type: 'REPORT_ERROR',
+              data: error,
+            })
             penpot.ui.sendMessage({
               type: 'POST_MESSAGE',
               data: {
@@ -267,8 +279,10 @@ const loadUI = async () => {
             penpot.ui.sendMessage({ type: 'STOP_LOADER' })
           })
           .catch((error) => {
-            console.error(error)
-
+            penpot.ui.sendMessage({
+              type: 'REPORT_ERROR',
+              data: error,
+            })
             penpot.ui.sendMessage({
               type: 'POST_MESSAGE',
               data: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,27 +45,31 @@ export default defineConfig(({ mode }) => {
     plugins: [
       excludeUnwantedCssPlugin(),
       preact(),
-      sentryVitePlugin({
-        org: 'yelbolt',
-        project: 'ui-color-palette',
-        authToken: env.SENTRY_AUTH_TOKEN,
-        sourcemaps: {
-          assets: './dist/**',
-          filesToDeleteAfterUpload: isDev ? undefined : '**/*.map',
-        },
-        release: {
-          name: env.VITE_APP_VERSION,
-          setCommits: {
-            auto: true,
-          },
-          finalize: true,
-          deploy: {
-            env: 'production',
-          },
-        },
-        telemetry: false,
-      }),
       viteSingleFile(),
+      ...(!isDev
+        ? [
+            sentryVitePlugin({
+              org: 'yelbolt',
+              project: 'ui-color-palette',
+              authToken: env.SENTRY_AUTH_TOKEN,
+              sourcemaps: {
+                assets: './dist/**',
+                filesToDeleteAfterUpload: isDev ? undefined : '**/*.map',
+              },
+              release: {
+                name: env.VITE_APP_VERSION,
+                setCommits: {
+                  auto: true,
+                },
+                finalize: true,
+                deploy: {
+                  env: 'production',
+                },
+              },
+              telemetry: false,
+            }),
+          ]
+        : []),
     ],
 
     define: {


### PR DESCRIPTION
Update the Sentry plugin inclusion to be conditional based on the development mode. Upgrade the versions of `utils-ui-color-palette` and `ui-ui-color-palette`. Replace `console.error` with `penpot.ui.sendMessage` for improved error reporting in the `loadUI` function. Fix the build script command separator for development mode.